### PR TITLE
Add additional meeting pages

### DIFF
--- a/generate_ics.py
+++ b/generate_ics.py
@@ -13,6 +13,26 @@ MEETING_TYPES = [
         "name": "Planning",
         "url": "https://www.stmewanparishcouncil.gov.uk/Planning_24621.aspx",
         "base_url": "https://www.stmewanparishcouncil.gov.uk"
+    },
+    {
+        "name": "Extra Ordinary Council",
+        "url": "https://www.stmewanparishcouncil.gov.uk/Extra_Ordinary_Council_Meeting_30589.aspx",
+        "base_url": "https://www.stmewanparishcouncil.gov.uk"
+    },
+    {
+        "name": "Finance, Staffing, General Purposes & Audit",
+        "url": "https://www.stmewanparishcouncil.gov.uk/Finance_Staffing_General_Purposes__and__Audit_24623.aspx",
+        "base_url": "https://www.stmewanparishcouncil.gov.uk"
+    },
+    {
+        "name": "Playing Fields",
+        "url": "https://www.stmewanparishcouncil.gov.uk/Playing_Fields_24624.aspx",
+        "base_url": "https://www.stmewanparishcouncil.gov.uk"
+    },
+    {
+        "name": "Rights of Way",
+        "url": "https://www.stmewanparishcouncil.gov.uk/Rights_of_Way_24622.aspx",
+        "base_url": "https://www.stmewanparishcouncil.gov.uk"
     }
 ]
 


### PR DESCRIPTION
## Summary
- expand `MEETING_TYPES` with pages for extra ordinary council, finance and staffing, playing fields, and rights of way
- these additional pages are scraped only for future meetings

## Testing
- `pip install -r requirements.txt`
- `python generate_ics.py`

------
https://chatgpt.com/codex/tasks/task_e_68500b606470832d8d8de15e5e5ee5f5